### PR TITLE
feature: remove memory restriction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ LABEL maintainer="Stéphane Bour <stephane.bour@gmail.com>"
 RUN curl -L https://phar.phpunit.de/phpcpd.phar -o /phpcpd
 
 COPY "entrypoint.sh" "/entrypoint.sh"
+COPY "memory_limit.ini" "/usr/local/etc/php/conf.d/memory_limit.ini"
 
 RUN chmod +x /entrypoint.sh && chmod a+x /phpcpd
 ENTRYPOINT ["/entrypoint.sh"]

--- a/memory_limit.ini
+++ b/memory_limit.ini
@@ -1,0 +1,1 @@
+memory_limit = -1


### PR DESCRIPTION
Description
---
There is no need to restrict memory on an action. Each runner has 4GB of memory and will simply fail if usage climbs beyond this.